### PR TITLE
Update to latest linux kernel

### DIFF
--- a/Linux/cp210x/build_install.py
+++ b/Linux/cp210x/build_install.py
@@ -1,28 +1,23 @@
 import tarfile
-from StringIO import StringIO
+from io import BytesIO
 
 def main():
-	installScript = open("install.sh.in").read()
-	payloadStart = len(installScript.splitlines()) + 1
-	#payloadStart = len(installScript) - 1 + len(str(len(installScript)))
-	#if len(installScript) - 1 + len(str(payloadStart)) != payloadStart:
-	#	payloadStart += 1
-	
-	print "payloadstart=%s" % payloadStart
-	installScript = installScript.replace("payloadstart=0", "payloadstart=%s" % payloadStart)
+    with open("install.sh.in", "r") as f:
+        installScript = f.read()
+    payloadStart = len(installScript.splitlines()) + 1
 
-	output = open("install.sh", 'wb')
-	
-	tarData = StringIO()
-	tarFile = tarfile.open(fileobj=tarData, mode='w:bz2')
-	tarFile.add("cp210x.c")
-	tarFile.add("Makefile")
-	tarFile.add("dkms.conf")
-	tarFile.close()
+    print(f"payloadstart={payloadStart}")
+    installScript = installScript.replace("payloadstart=0", f"payloadstart={payloadStart}")
 
-	output.write(installScript)
-	output.write(tarData.getvalue())
-	output.close()
-	
+    with open("install.sh", 'wb') as output:
+        tarData = BytesIO()
+        with tarfile.open(fileobj=tarData, mode='w:bz2') as tarFile:
+            tarFile.add("cp210x.c")
+            tarFile.add("Makefile")
+            tarFile.add("dkms.conf")
+
+        output.write(installScript.encode())
+        output.write(tarData.getvalue())
+
 if __name__ == "__main__":
-	main()
+    main()

--- a/Linux/cp210x/cp210x.c
+++ b/Linux/cp210x/cp210x.c
@@ -47,7 +47,7 @@ static int cp210x_tiocmset_port(struct usb_serial_port *port,
 		unsigned int, unsigned int);
 static void cp210x_break_ctl(struct tty_struct *, int);
 static int cp210x_port_probe(struct usb_serial_port *);
-static int cp210x_port_remove(struct usb_serial_port *);
+static void cp210x_port_remove(struct usb_serial_port *);
 static void cp210x_dtr_rts(struct usb_serial_port *p, int on);
 
 static const struct usb_device_id id_table[] = {
@@ -1375,14 +1375,12 @@ static int cp210x_port_probe(struct usb_serial_port *port)
 	return 0;
 }
 
-static int cp210x_port_remove(struct usb_serial_port *port)
+static void cp210x_port_remove(struct usb_serial_port *port)
 {
 	struct cp210x_port_private *port_priv;
 
 	port_priv = usb_get_serial_port_data(port);
 	kfree(port_priv);
-
-	return 0;
 }
 
 module_usb_serial_driver(serial_drivers, id_table);


### PR DESCRIPTION
the `cp210x_port_remove` function signature has changed to return void instead of an int in the latest kernel headers.

Thanks!